### PR TITLE
Pass subsets to extract_array() when discarding dimensions.

### DIFF
--- a/tests/test_DelayedArray.py
+++ b/tests/test_DelayedArray.py
@@ -697,6 +697,8 @@ def test_DelayedArray_subset():
     # Falls back to a concrete numpy.ndarray
     stuff = x[:, :, 2]
     assert (stuff == y[:, :, 2]).all()
+    stuff = x[0, :, 2]
+    assert (stuff == y[0, :, 2]).all()
 
     # Works with dask arrays.
     da = delayedarray.create_dask_array(x)


### PR DESCRIPTION
This avoids realizing the entire array to extract a lower-dimensional slice.